### PR TITLE
Add new versions to workflow and remove use of untainted

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,27 +1,31 @@
+---
 name: Run tests
-on: [push, pull_request]
+on: [push, pull_request]  # yamllint disable-line rule:truthy
 jobs:
   test:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby: [
+          '2.3', '2.4', '2.5', '2.6', '2.7',
+          '3.0', '3.1', '3.2', '3.3', '3.4'
+        ]
     runs-on: ubuntu-latest
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/spec/spec.gemfile
     steps:
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
-    - run: bundle exec rspec
+      - uses: actions/checkout@v5
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rspec
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.7
-        bundler-cache: true
-    - run: bundle exec rubocop
+      - uses: actions/checkout@v5
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - run: bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-ruby '2.7.7'
+ruby '2.7.8'
 
 # Specify your gem's dependencies in resolv-hosts-dynamic.gemspec
 gemspec

--- a/lib/resolv-hosts-dynamic.rb
+++ b/lib/resolv-hosts-dynamic.rb
@@ -35,9 +35,6 @@ class Resolv
           raise "Must specify 'addr' for host" unless addr
           raise "Must specify 'hostname' for host" unless hostname
 
-          addr.untaint
-          hostname.untaint
-
           # So that aliases can be passed a string or an array of strings
           aliases = [aliases] if aliases.is_a? String
 
@@ -47,7 +44,6 @@ class Resolv
           @name2addr[hostname] = [] unless @name2addr.include? hostname
           @name2addr[hostname] << addr
           aliases&.each do |n|
-            n.untaint
             @name2addr[n] = [] unless @name2addr.include? n
             @name2addr[n] << addr
           end


### PR DESCRIPTION
* Add new ruby versions to workflow
* Remove use of deprecated `untaint` method.
   It was removed in <https://bugs.ruby-lang.org/issues/16131>

